### PR TITLE
Fix dangling pointer in new_from_names

### DIFF
--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -627,7 +627,7 @@ impl Keymap {
         let cmodel = CString::new(model.borrow().as_bytes()).unwrap();
         let clayout = CString::new(layout.borrow().as_bytes()).unwrap();
         let cvariant = CString::new(variant.borrow().as_bytes()).unwrap();
-        let (_, poptions) = match options {
+        let (_coptions, poptions) = match options {
             None => (CString::new(Vec::new()).unwrap(), null()),
             Some(s) => {
                 let coptions = CString::new(s.into_bytes()).unwrap();


### PR DESCRIPTION
The old code created a CString which was immediately dropped.
The `poptions` pointer of that CString was invalid when calling
`xkb_keymap_new_from_names`

Assigning the CString to `_coptions` instead of `_` creates a binding
which will drop only when the `new_from_names` function exits.