### PR TITLE
keymap: fix use-after-free

### DIFF
--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -627,6 +627,7 @@ impl Keymap {
         let cmodel = CString::new(model.borrow().as_bytes()).unwrap();
         let clayout = CString::new(layout.borrow().as_bytes()).unwrap();
         let cvariant = CString::new(variant.borrow().as_bytes()).unwrap();
+        // "_coptions" (as opposed to "_") avoids use-after-free for any option passed to this function
         let (_coptions, poptions) = match options {
             None => (CString::new(Vec::new()).unwrap(), null()),
             Some(s) => {


### PR DESCRIPTION
This is a fix for 0.4.0.

`let _ = ...` drops immediately (different to `let _unused = ...`), which causes a use-after-free for any options passed to `Keymap::new_from_names`.

I would highly appreciate a 0.4.1 release with this fix, even if 0.5 is already in development, if that doesn't cause too much of a hassle. Thanks!