### PR TITLE
Replace "xcb" with "as-raw-xcb-connection"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,6 @@ jobs:
             libxkbcommon-dev \
             libxkbcommon-x11-dev
 
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
-
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ all-features = true
 [dependencies]
 libc = "0.2.125"
 memmap2 = { version = "0.5.3", optional = true }
-xcb = { version = "1.1.1", features = ["xkb"], optional = true }
+as-raw-xcb-connection = { version = "1.0", optional = true }
 
 [dev-dependencies]
 evdev = "0.11.4"
 
 [features]
 default = ["wayland"]
-x11 = ["xcb"]
+x11 = ["as-raw-xcb-connection"]
 wayland = ["memmap2"]
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 extern crate libc;
 #[cfg(feature = "wayland")]
 extern crate memmap2;
-#[cfg(feature = "x11")]
-extern crate xcb;
 
 pub mod xkb;

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -81,7 +81,7 @@ pub type Keycode = u32;
 ///
 /// Besides those, any Unicode/ISO 10646 character in the range U0100 to
 /// U10FFFF can be represented by a keysym value in the range 0x01000100 to
-/// 0x0110FFFF. The name of Unicode keysyms is "U<codepoint>", e.g. "UA1B2".
+/// 0x0110FFFF. The name of Unicode keysyms is "`U<codepoint>`", e.g. "UA1B2".
 ///
 /// The name of other unnamed keysyms is the hexadecimal representation of
 /// their value, e.g. "0xabcd1234".

--- a/src/xkb/x11/ffi.rs
+++ b/src/xkb/x11/ffi.rs
@@ -1,7 +1,7 @@
 use crate::xkb::ffi::{xkb_context, xkb_keymap, xkb_keymap_compile_flags, xkb_state};
 
+use as_raw_xcb_connection::xcb_connection_t;
 use std::os::raw::c_int;
-use xcb::ffi::xcb_connection_t;
 
 pub const XKB_X11_MIN_MAJOR_XKB_VERSION: u16 = 1;
 pub const XKB_X11_MIN_MINOR_XKB_VERSION: u16 = 0;

--- a/src/xkb/x11/mod.rs
+++ b/src/xkb/x11/mod.rs
@@ -2,8 +2,8 @@ pub mod ffi;
 
 use self::ffi::*;
 use super::{Context, Keymap, KeymapCompileFlags, State};
+use as_raw_xcb_connection::AsRawXcbConnection;
 use std::mem;
-use xcb;
 
 pub const MIN_MAJOR_XKB_VERSION: u16 = 1;
 pub const MIN_MINOR_XKB_VERSION: u16 = 0;
@@ -15,7 +15,7 @@ pub enum SetupXkbExtensionFlags {
 }
 
 pub fn setup_xkb_extension(
-    connection: &xcb::Connection,
+    connection: impl AsRawXcbConnection,
     major_xkb_version: u16,
     minor_xkb_version: u16,
     flags: SetupXkbExtensionFlags,
@@ -26,7 +26,7 @@ pub fn setup_xkb_extension(
 ) -> bool {
     unsafe {
         xkb_x11_setup_xkb_extension(
-            connection.get_raw_conn(),
+            connection.as_raw_xcb_connection(),
             major_xkb_version,
             minor_xkb_version,
             mem::transmute(flags),
@@ -39,21 +39,21 @@ pub fn setup_xkb_extension(
 }
 
 #[must_use]
-pub fn get_core_keyboard_device_id(connection: &xcb::Connection) -> i32 {
-    unsafe { xkb_x11_get_core_keyboard_device_id(connection.get_raw_conn()) as i32 }
+pub fn get_core_keyboard_device_id(connection: impl AsRawXcbConnection) -> i32 {
+    unsafe { xkb_x11_get_core_keyboard_device_id(connection.as_raw_xcb_connection()) as i32 }
 }
 
 #[must_use]
 pub fn keymap_new_from_device(
     context: &Context,
-    connection: &xcb::Connection,
+    connection: impl AsRawXcbConnection,
     device_id: i32,
     flags: KeymapCompileFlags,
 ) -> Keymap {
     unsafe {
         Keymap::from_raw_ptr(xkb_x11_keymap_new_from_device(
             context.get_raw_ptr(),
-            connection.get_raw_conn(),
+            connection.as_raw_xcb_connection(),
             device_id,
             flags,
         ))
@@ -63,13 +63,13 @@ pub fn keymap_new_from_device(
 #[must_use]
 pub fn state_new_from_device(
     keymap: &Keymap,
-    connection: &xcb::Connection,
+    connection: impl AsRawXcbConnection,
     device_id: i32,
 ) -> State {
     unsafe {
         State::from_raw_ptr(xkb_x11_state_new_from_device(
             keymap.get_raw_ptr(),
-            connection.get_raw_conn(),
+            connection.as_raw_xcb_connection(),
             device_id,
         ))
     }


### PR DESCRIPTION
There is a new crate "as-raw-xcb-connection" which provides a trait that can be used to get a raw pointer to a libxcb xcb_connection_t. This trait allows this crate to work with arbitrary versions of crates (as long as they implement this trait).

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

This is a draft since I want to wait for version 1.0 of AsRawXcbConnection before merging. See https://github.com/psychon/as-raw-xcb-connection/issues/1