### PR TITLE
Fix panic in key_get_utf8

### DIFF
--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -1307,10 +1307,14 @@ impl State {
     #[must_use]
     pub fn key_get_utf8(&self, key: Keycode) -> String {
         unsafe {
-            let buf: &mut [c_char] = &mut [0; 64];
+            const BUF_LEN: usize = 64;
+            let buf: &mut [c_char] = &mut [0; BUF_LEN];
             let ptr = &mut buf[0] as *mut c_char;
-            let len = xkb_state_key_get_utf8(self.ptr, key.into(), ptr, 64);
-            let slice: &[u8] = slice::from_raw_parts(ptr as *const _, len as usize);
+            let ret = xkb_state_key_get_utf8(self.ptr, key.into(), ptr, BUF_LEN);
+            // len is similar to the rerurn value of snprintf.
+            // it may be negative on unspecified errors, or >64 if the buffer is too small.
+            let len = (ret as usize).max(0).min(BUF_LEN);
+            let slice: &[u8] = slice::from_raw_parts(ptr as *const _, len);
             String::from_utf8_unchecked(slice.to_owned())
         }
     }

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -1313,8 +1313,8 @@ impl State {
             let ret = xkb_state_key_get_utf8(self.ptr, key.into(), ptr, BUF_LEN);
             // len is similar to the rerurn value of snprintf.
             // it may be negative on unspecified errors, or >64 if the buffer is too small.
-            let len = (ret as usize).max(0).min(BUF_LEN);
-            let slice: &[u8] = slice::from_raw_parts(ptr as *const _, len);
+            let len = ret.max(0).min(BUF_LEN as i32);
+            let slice: &[u8] = slice::from_raw_parts(ptr as *const _, len as usize);
             String::from_utf8_unchecked(slice.to_owned())
         }
     }

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -299,10 +299,14 @@ pub fn keycode_is_legal_x11(key: u32) -> bool {
 #[must_use]
 pub fn keysym_get_name(keysym: Keysym) -> String {
     unsafe {
-        let buf: &mut [c_char] = &mut [0; 64];
+        const BUF_LEN: usize = 64;
+        let buf: &mut [c_char] = &mut [0; BUF_LEN];
         let ptr = &mut buf[0] as *mut c_char;
-        let len = xkb_keysym_get_name(keysym.raw(), ptr, 64);
-        let slice: &[u8] = slice::from_raw_parts(ptr as *const _, len as usize);
+        let len = xkb_keysym_get_name(keysym.raw(), ptr, BUF_LEN);
+        if len <= 0 {
+            return String::new();
+        }
+        let slice: &[u8] = slice::from_raw_parts(ptr as *const _, (len as usize).min(BUF_LEN));
         String::from_utf8_unchecked(slice.to_owned())
     }
 }
@@ -1311,7 +1315,7 @@ impl State {
             let buf: &mut [c_char] = &mut [0; BUF_LEN];
             let ptr = &mut buf[0] as *mut c_char;
             let ret = xkb_state_key_get_utf8(self.ptr, key.into(), ptr, BUF_LEN);
-            // len is similar to the rerurn value of snprintf.
+            // ret is similar to the return value of snprintf.
             // it may be negative on unspecified errors, or >64 if the buffer is too small.
             let len = ret.max(0).min(BUF_LEN as i32);
             let slice: &[u8] = slice::from_raw_parts(ptr as *const _, len as usize);


### PR DESCRIPTION
At Zed, we see a "capacity overflow" from some users in this function.

I don't know under what circumstances exactly, but the documentation for xkb_state_get_utf8 says it has a return value "similar" to snprintf, which may return a negative number on unspecified error, or a length larger than the buffer in the case of overflow.

This fix returns the empty string on error, and truncates characters longer than 64 bytes to avoid reading unitialized memory