### PR TITLE
don't truncate xkb_keymap_new_from_buffer 

### DIFF
--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -749,8 +749,7 @@ impl Keymap {
             .len(size as usize)
             // Starting in version 7 of the wl_keyboard protocol, the keymap must be mapped using MAP_PRIVATE.
             .map_copy_read_only(&fs::File::from(fd))?;
-        let ptr =
-            xkb_keymap_new_from_buffer(context.ptr, map.as_ptr().cast(), size, format, flags);
+        let ptr = xkb_keymap_new_from_buffer(context.ptr, map.as_ptr().cast(), size, format, flags);
         if ptr.is_null() {
             Ok(None)
         } else {

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -750,7 +750,7 @@ impl Keymap {
             // Starting in version 7 of the wl_keyboard protocol, the keymap must be mapped using MAP_PRIVATE.
             .map_copy_read_only(&fs::File::from(fd))?;
         let ptr =
-            xkb_keymap_new_from_buffer(context.ptr, map.as_ptr().cast(), size - 1, format, flags);
+            xkb_keymap_new_from_buffer(context.ptr, map.as_ptr().cast(), size, format, flags);
         if ptr.is_null() {
             Ok(None)
         } else {


### PR DESCRIPTION
Truncating the size by one will break some applications such as wvkbd when running on smithay.

I have confirmed this to fix wvkbd running on both cosmic-comp and niri 

fixes: #58