### PR TITLE
impl Default for xkb::Context

### DIFF
--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -519,6 +519,12 @@ impl Context {
     }
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Self::new(CONTEXT_NO_FLAGS)
+    }
+}
+
 impl Clone for Context {
     fn clone(&self) -> Context {
         unsafe {


### PR DESCRIPTION
Add a `Default` implementation for `xkb::Context`. The `CONTEXT_NO_FLAGS` flag is used when a default Context is created.

Use case:
In my library, I have a struct with many fields. They all implement Default except for xkb::Context so I am unable to derive(Default). This PR fixes that "problem" and allows users of xkbcommon to write more concise code.